### PR TITLE
Fix sanitize_settings to handle settings that are NULL.

### DIFF
--- a/includes/base/controls-stack.php
+++ b/includes/base/controls-stack.php
@@ -1910,7 +1910,11 @@ abstract class Controls_Stack extends Base_Object {
 	 *
 	 * @return array Sanitized settings.
 	 */
-	private function sanitize_settings( array $settings, array $controls = [] ) {
+	private function sanitize_settings( ?array $settings, array $controls = [] ) {
+		if(is_null($settings)){
+			$settings = [];
+		}
+		
 		if ( ! $controls ) {
 			$controls = $this->get_controls();
 		}


### PR DESCRIPTION
When I open a page with Elementor in Wordpress 5.3 I get the following exception:
```
Fatal error: Uncaught TypeError: Argument 1 passed to Elementor\Controls_Stack::sanitize_settings() must be of the type array, null given, called in /homepages/23/d438281368/htdocs/clickandbuilds/Justponics/wp-content/plugins/elementor/includes/base/controls-stack.php on line 1023 and defined in /homepages/23/d438281368/htdocs/clickandbuilds/Justponics/wp-content/plugins/elementor/includes/base/controls-stack.php:1913 Stack trace: #0 /homepages/23/d438281368/htdocs/clickandbuilds/Justponics/wp-content/plugins/elementor/includes/base/controls-stack.php(1023): Elementor\Controls_Stack->sanitize_settings(NULL) #1 /homepages/23/d438281368/htdocs/clickandbuilds/Justponics/wp-content/plugins/elementor/includes/base/controls-stack.php(1776): Elementor\Controls_Stack->get_data('settings') #2 /homepages/23/d438281368/htdocs/clickandbuilds/Justponics/wp-content/plugins/elementor/core/base/base-object.php(132): Elementor\Controls_Stack->get_init_settings() #3 /homepages/23/d438281368/htdocs/clickandbuilds/Justponics/wp-content/plugi in /homepages/23/d438281368/htdocs/clickandbuilds/Justponics/wp-content/plugins/elementor/includes/base/controls-stack.php on line 1913
Uncaught TypeError: Argument 1 passed to Elementor\Controls_Stack::sanitize_settings() must be of the type array, null given, called in /homepages/23/d438281368/htdocs/clickandbuilds/Justponics/wp-content/plugins/elementor/includes/base/controls-stack.php on line 1023 and defined in /homepages/23/d438281368/htdocs/clickandbuilds/Justponics/wp-content/plugins/elementor/includes/base/controls-stack.php:1913
Stack trace:
#0 /homepages/23/d438281368/htdocs/clickandbuilds/Justponics/wp-content/plugins/elementor/includes/base/controls-stack.php(1023): Elementor\Controls_Stack->sanitize_settings(NULL)
#1 /homepages/23/d438281368/htdocs/clickandbuilds/Justponics/wp-content/plugins/elementor/includes/base/controls-stack.php(1776): Elementor\Controls_Stack->get_data('settings')
#2 /homepages/23/d438281368/htdocs/clickandbuilds/Justponics/wp-content/plugins/elementor/core/base/base-object.php(132): Elementor\Controls_Stack->get_init_settings()
#3 /homepages/23/d438281368/htdocs/clickandbuilds/Justponics/wp-content/plugin
```

The issue is that sanitize_settings is getting passed a null value when it expects an array.

## PR Checklist
<!-- 
Please check if your PR fulfills the following requirements:
**Filling out the template is required.** Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
 -->
- [ ] The commit message follows our guidelines:  https://github.com/elementor/elementor/blob/master/.github/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x" with no spaces eg: [x]. -->
- [ X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Summary

This PR can be summarized in the following changelog entry:

* the sanitize_settings function is getting passed a null value when it expects an array, which causes an exception to be thrown

## Description
An explanation of what is done in this PR

* Fix sanitize_settings to allow a NULL value as the settings parameter and to initialize the settings parameter to an array if it is null 

## Test instructions
This PR can be tested by following these steps:

*

## Quality assurance

- [ X] I have tested this code to the best of my abilities
- [ ] I have added unittests to verify the code works as intended
- [ ] Docs have been added / updated (for bug fixes / features)

Fixes #
